### PR TITLE
rawToChar Encoding Fix

### DIFF
--- a/R/influxdb_helper.R
+++ b/R/influxdb_helper.R
@@ -70,7 +70,7 @@ check_srv_comm <- function(x) {
   #     The returned JSON offers further information.
   
   if (!x$status_code %in% c(200, 204)) {
-    response_data <- jsonlite::fromJSON(rawToChar(x$content))
+    response_data <- jsonlite::fromJSON(httr::content(x, "text", encoding="UTF-8"))
     stop(response_data$error, call. = FALSE)
   }
   

--- a/R/influxdb_post.R
+++ b/R/influxdb_post.R
@@ -28,7 +28,7 @@ influx_post <- function(con,
   # Check for communication errors
   check_srv_comm(response)
   
-  response <- rawToChar(response$content) %>%  # convert to chars
+  response <- httr::content(response, "text", encoding="UTF-8") %>%  # convert to chars
     purrr::map(response_to_list) %>%
     purrr::map_df(post_list_to_tibble)
   

--- a/R/influxdb_query.R
+++ b/R/influxdb_query.R
@@ -60,11 +60,11 @@ influx_query <- function(con,
   # Check for communication errors
   check_srv_comm(response)
   
-  # debug_data <<- rawToChar(response$content)
+  # debug_data <<- httr::content(response, "text", encoding="UTF-8")
   
   # initiate data conversion which result in a tibble with list-columns
   list_of_result <-
-    rawToChar(response$content) %>%  # convert to chars
+    httr::content(response, "text", encoding="UTF-8") %>%  # convert to chars
     purrr::map(response_to_list) %>% # from json to list
     purrr::map(query_list_to_tibble, # from list to tibble
                timestamp_format = timestamp_format) %>% 


### PR DESCRIPTION
Session locale encoding influences response handling:

``` r
devtools::session_info()
## Session info ---------------------------------------------------------------------------------------
##  setting  value                       
##  version  R version 3.4.3 (2017-11-30)
##  system   x86_64, mingw32             
##  ui       RStudio (1.1.423)           
##  language (EN)                        
##  collate  English_Switzerland.1252    
##  tz       Europe/Berlin               
##  date     2018-02-17    

df$einheit
## "µg/m3"
influx_write(df, con, "rmo", "test", time_col="startzeit", tag_cols = c("airmo_kurzname", "parameter", "zeitfenster", "einheit"))
res <- influx_select(con, db = "rmo", field_keys = "airmo_kurzname, parameter, einheit, value", measurement = "test", return_xts = FALSE)
res[[1]]$einheit
## "Âµg/m3"
```

Replacing the rawToChar(response$content) with httr::content(response, "text", encoding="UTF-8") fixes the issue.




