### PR TITLE
Rewrite writing sub-system

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ Imports:
     jsonlite,
     httr,
     magrittr,
+    progress,
     purrr (>= 0.2.3),
     rlang,
     tibble,

--- a/R/influxdb_connection.R
+++ b/R/influxdb_connection.R
@@ -50,19 +50,24 @@ influx_connection <-  function(scheme = c("http", "https"),
       lines <- readLines(con)
       
       # find line with groupname
-      grp <- grep(paste0("[", group, "]"), x = lines, fixed = T)
+      grp <- grep(sprintf("^ *\\[%s\\]", group), x = lines)
       
       # catch the case if group name is not found
       if (identical(grp, integer(0)))
         stop("Group does not exist in config file.")
+
+      if (length(grp) > 1)
+        stop(sprintf("Multiple groups with the same name (%s) in config file.", group))
+
+      the_lines <- lines[(grp + 1):min(grp + 6, length(lines))]
       
       # get db credentials
-      scheme <- gsub("scheme=", "", grep("scheme=", lines[(grp + 1):(grp + 6)], fixed = T, value = T))
-      host <- gsub("host=", "", grep("host=", lines[(grp + 1):(grp + 6)], fixed = T, value = T))
-      port <- as.numeric(gsub("port=", "", grep("port=", lines[(grp + 1):(grp + 6)], fixed = T, value = T)))
-      user <- gsub("user=", "", grep("user=", lines[(grp + 1):(grp + 6)], fixed = T, value = T))
-      pass <- gsub("pass=", "", grep("pass=", lines[(grp + 1):(grp + 6)], fixed = T, value = T))
-      path <- gsub("path=", "", grep("path=", lines[(grp + 1):(grp + 6)], fixed = T, value = T))
+      scheme <- gsub("scheme=", "", grep("scheme=", the_lines, fixed = T, value = T))
+      host <- gsub("host=", "", grep("host=", the_lines, fixed = T, value = T))
+      port <- as.numeric(gsub("port=", "", grep("port=", the_lines, fixed = T, value = T)))
+      user <- gsub("user=", "", grep("user=", the_lines, fixed = T, value = T))
+      pass <- gsub("pass=", "", grep("pass=", the_lines, fixed = T, value = T))
+      path <- gsub("path=", "", grep("path=", the_lines, fixed = T, value = T))
       
       # close file connection
       close(con)

--- a/R/influxdb_line_protocol.R
+++ b/R/influxdb_line_protocol.R
@@ -6,18 +6,18 @@ convert_to_line_protocol <- function(x,
                                      precision,
                                      use_integers = FALSE,
                                      ...) {
-  
+
   UseMethod("convert_to_line_protocol", x)
-  
+
 }
 
 #' @keywords internal
 convert_to_line_protocol.xts <- function(x,
                                          measurement,
                                          precision,
-                                         use_integers = FALSE, 
+                                         use_integers = FALSE,
                                          ...) {
-  
+
   # catch error no XTS object
   if (!xts::is.xts(x))
     stop("Object is not an xts-object.")
@@ -27,38 +27,38 @@ convert_to_line_protocol.xts <- function(x,
   # catch error nrow
   if (nrow(x) == 0)
     stop("nrow(xts) is 0.")
-  
+
   # remove rows with NA's only
   x <- x[rowSums(is.na(x)) != ncol(x),]
-  
+
   # take only valid attributes
   valid_attr <- which(xts::xtsAttributes(x) != "")
-  
+
   # extract tag keys and tag values
   tag_keys <- names(xts::xtsAttributes(x)[valid_attr])
   tag_values <- xts::xtsAttributes(x)[valid_attr]
-  
+
   # handle special characters
-  measurement <- replace_spec_char(measurement, chars = c(",", " "))
-  tag_keys <- replace_spec_char(tag_keys, chars = c(",", "=", " "))
-  tag_values <- replace_spec_char(tag_values, chars = c(",", "=", " "))
-    
+  measurement <- replace_spec_char(measurement, do_equal = FALSE)
+  tag_keys <- replace_spec_char(tag_keys)
+  tag_values <- replace_spec_char(tag_values)
+
   # handle empty values in keys
   tag_values <- gsub(pattern = "numeric\\(0\\)|character\\(0\\)",
                      replacement = "NA",
                      x = tag_values)
-  
+
   # merge tag keys and values
   tag_key_value <-
     paste(tag_keys, tag_values, sep = "=", collapse = ",")
-  
+
   # create time vector
   time <- format(as.numeric(zoo::index(x)) * get_precision_divisor(precision),
                  scientific = FALSE)
-  
-  # default NA string 
+
+  # default NA string
   na_string <- "NA"
-  
+
   # make sure all integers end with "i", this also sets mode to "character"
   # s. https://github.com/influxdb/influxdb/issues/3519
   if ((use_integers == TRUE) & is.numeric(x)) {
@@ -67,7 +67,7 @@ convert_to_line_protocol.xts <- function(x,
       # define na_string to substitute later
       na_string <- "NAi"
     }
-    
+
   } else {
     if (!is.numeric(x)) {
       # add quotes if matrix contains no numerics i.e. -> characters
@@ -75,41 +75,41 @@ convert_to_line_protocol.xts <- function(x,
       quotes <- getOption("useFancyQuotes")
       on.exit(options("useFancyQuotes" = quotes))
       options("useFancyQuotes" = FALSE)
-      
+
       x[, ] <- sapply(seq_len(ncol(x)), function(y) base::dQuote(x[, y]))
       # trim leading and trailing whitespaces
       x <- gsub("^\\s+|\\s+$", "", x)
       # define na_string to substitute later
       na_string <- paste0("\"", "NA", sep = "\"")
     }
-    
+
   }
-  
+
   # assign columnname to each element
   values <- sapply(seq_len(ncol(x)),
                    function(y)
                      paste(colnames(x)[y],
                            zoo::coredata(x)[, y],
                            sep = "="))
-  
+
   # set R's NA values to a dummy string which can be removed easily
   # -> influxdb doesn't handle NA values
   # TODO: What if columnname contains "NA" ?
   values[grepl(na_string, values, fixed = TRUE)] <- "NA_to_remove"
-  
+
   # If values have only one row, 'apply' will result in a dim error.
   # This occurs if the previous 'sapply' result a character vector.
   # Thus, check if a conversion is required:
   if (is.null(dim(values))) {
     dim(values) <- length(values)
   }
-  
+
   # paste and collapse rows
   values <- apply(values, 1, paste, collapse = ",")
-  
+
   # remove dummy strings
   values <- gsub(",NA_to_remove|NA_to_remove,", "", values)
-  
+
   # no tags assigned
   if (is.null(tag_values) | identical(character(0), tag_values)) {
     influxdb_line_protocol <- paste(measurement,
@@ -128,193 +128,147 @@ convert_to_line_protocol.xts <- function(x,
       collapse = "\n"
     )
   }
-  
+
   # invisibly return InfluxDB line protocol string
   invisible(influxdb_line_protocol)
-  
+
 }
 
 #' @keywords internal
-convert_to_line_protocol.data.frame <- function(x, 
+convert_to_line_protocol.data.frame <- function(x,
                                                 measurement = NULL,
                                                 precision = NULL,
                                                 use_integers = FALSE,
-                                                ...,
                                                 measurement_col = NULL,
                                                 tag_cols = NULL,
-                                                time_col = NULL) {
-  
-  # stop if data.frame provided contains NA's
-  if (!all(!purrr::map_lgl(x, ~ any(is.na(.))))) {
-    
-    print(x %>% 
-            purrr::map( ~ which(is.na(.), arr.ind = T)) %>% # transform to logical 
-            purrr::keep( ~ length(.x) > 0)) # discard integer(0)
-    
-    stop("Handling of NA's in data.frames is currently not supported. 
-         Rows containing NA's are given above!")  
-    
+                                                time_col = NULL,
+                                                ...) {
+
+  # stop if measurements contain NA's
+  val_cols <- setdiff(colnames(x), c(tag_cols, time_col))
+  for (nm in val_cols) {
+    if (!(is.character(x[[nm]]) || is.factor(x[[nm]]))) {
+      if (anyNA(x[[nm]])) {
+        stop(sprintf("Handling of NA's in data.frames is currently not supported (col: '%s').", nm))
+      }
+    }
   }
-  
-  # no measurement name is given
-  if (is.null(measurement) & is.null(measurement_col)) {
-    stop("measurement must be specified")
+
+  # MEASUREMENT
+  the_measurement <-
+    if (!is.null(measurement_col)) {
+      validate_scalar_var(x, measurement_col)
+      list(replace_spec_char(x[[measurement_col]], FALSE))
+    } else if (!is.null(measurement)) {
+      validate_scalar_var(x, measurement, FALSE)
+      list(replace_spec_char(measurement, FALSE))
+    } else {
+      stop("`measurement` or `measurement_col` must be specified.")
+    }
+
+  # TAG SET (optional)
+  the_tags <- list()
+  for (nm in tag_cols) {
+    the_tags <- append(the_tags,
+                       list(",",
+                            replace_spec_char(nm),
+                            "=",
+                            replace_spec_char(x[[nm]])))
   }
-  
-  # name of measurement is given with argument "measurement" 
-  # single measurement per data.frame
-  if (!is.null(measurement) & is.null(measurement_col)) {
-  
-    # handling of special character in measurement name
-    measurement <- replace_spec_char(measurement, chars = c(",", " "))
-    tbl_measurement <- tibble::tibble(measurement = rep(measurement, 
-                                                        times = nrow(x)))  
-    
-  }
-  
-  # name of measurement is given with argument "measurement_col"
-  # multiple measurement per data.frame
-  # overrides `measurement` function argument
-  if (!is.null(measurement_col)) {
-    
-    tbl_measurement <- x %>% 
-      dplyr::select(measurement_col) %>% 
-      dplyr::mutate_all(dplyr::funs(replace_spec_char(., chars = c(",", " ")))) 
-    
-    # remove column from df
-    x <- dplyr::select(x, -dplyr::one_of(measurement_col))
-    
-  }
-  
-  # TAG SET (are not necessary)
-  if (!is.null(tag_cols)) {
-    tbl_tags <- x %>%
-      # select only tag column
-      dplyr::select(dplyr::one_of(tag_cols)) %>%
-      # handling of special characters in tag keys
-      dplyr::rename_all(dplyr::funs(replace_spec_char(., chars = c(",", "=", " ")))) %>%
-      # handling of special characters in tag values
-      dplyr::mutate_all(dplyr::funs(replace_spec_char(., chars = c(",", "=", " ")))) %>%
-      # create tag set
-      purrr::imap_dfr( ~ paste(.y, .x, sep = "=")) %>% 
-      tidyr::unite(col = "tags", dplyr::everything(), sep = ",") %>% 
-      dplyr::mutate(tags = paste(",", tags, sep = ""))
-    
-  } else {
-    tbl_tags <- NULL
-  }
-  
-  # for dquotes in fields of type character
-  # check Option useFancyQuotes
-  quotes <- getOption("useFancyQuotes")
-  on.exit(options("useFancyQuotes" = quotes))
-  options("useFancyQuotes" = FALSE)
-  
+
   # FIELD SET
-  tbl_values <- x %>%
-    # use all columns as fields except for tags and time 
-    `if`(!all(is.null(tag_cols), is.null(time_col)), 
-         dplyr::select(., -dplyr::one_of(tag_cols, time_col)), .) %>%
-    # remove ws
-    dplyr::mutate_if(., is.character, base::trimws) %>% 
-    # double quote character columns
-    dplyr::mutate_if(., is.character, base::dQuote) %>%
-    # handling of special characters in field keys
-    # opt1: substitute all whitespaces and non-word character
-    #dplyr::rename_all(dplyr::funs(gsub("\\s+|\\W", "_", x = .))) %>%
-    # opt2: dquote if whitespaces or non-word character is in colname
-    #dplyr::rename_if(grepl("\\s+|\\W", x = names(.)), base::dQuote) %>% 
-    # opt3: apply escape rule of InfluxDb
-    dplyr::rename_all(dplyr::funs(replace_spec_char(., chars = c(",", "=", " ")))) %>%
-    #dplyr::rename_if(grepl("\\s+|\\W", x = names(.)), base::sQuote) %>%
-    #dplyr::rename_all(dplyr::funs(gsub("`", "", x = .))) %>%
-    # add i in case for integers
-    `if`(use_integers, dplyr::mutate_if(., is.integer, paste, "i", sep=""), .) %>%
-    # create field set
-    purrr::imap_dfr( ~ paste(.y, .x, sep = "=")) %>% 
-    tidyr::unite(col = "values", dplyr::everything(), sep = ",") %>% 
-    # add leading and trailing ws
-    dplyr::mutate(values = paste(" ", values, " ", sep = ""))
-  
-  # TIME (is not necessary, server time is used if not given)
-  if (!is.null(time_col)) {
-    tbl_time <- x %>% 
-      # select time column if provided 
-      dplyr::select(dplyr::one_of(time_col)) %>% 
-      # rename for easier coding
-      dplyr::rename(time = !!time_col) %>% 
-      dplyr::mutate(time = format(as.numeric(time) * get_precision_divisor(precision),
-                                  scientific = FALSE))
-    
-  } else {
-    tbl_time <- NULL
+  the_vals <- list()
+  for (nm in val_cols) {
+    the_vals <- append(the_vals,
+                       list(",",
+                            replace_spec_char(nm), # name
+                            "=",
+                            double_quote(x[[nm]]), # value
+                            if(use_integers && is.integer(x[[nm]])) "i"))
   }
-  
-  # merge all columns back to one tibble and make one chr vector
-  influxdb_line_protocol <- dplyr::bind_cols(tbl_measurement,
-                                             tbl_tags,
-                                             tbl_values, 
-                                             tbl_time) %>% 
-    tidyr::unite("line_protocol",
-                 dplyr::everything(), 
-                 sep = "") %>% 
-    purrr::flatten_chr() %>%
-    purrr::map_chr(base::trimws) %>% 
-    paste(., collapse = "\n")
-  
-  # invisibly return converted line protocol
-  invisible(influxdb_line_protocol)
-  
+  if (length(val_cols) > 0)
+    the_vals[[1]] <- " "
+
+  # TIME (optional; defaults to the server time)
+  the_time <- list()
+  if (!is.null(time_col)) {
+    validate_scalar_var(x, time_col)
+    the_time <- list(" ", format_time(x[[time_col]], precision))
+  }
+
+  invisible(do.call(paste0, c(the_measurement, the_tags, the_vals, the_time)))
+
 }
 
 # method to convert the line protocol to a data.frame
 # function is not exported
 #' @keywords internal
 line_protocol_to_array <- function(x) {
-  
+
   # substitute [ ], [,] and [=]
   x <- gsub("\\ ", replacement = " ", x, fixed = TRUE)
   x <- gsub("\\,", replacement = ";;;ABC;;;", x, fixed = TRUE) # dummy
   x <- gsub("\\=", replacement = "=", x, fixed = TRUE)
-  
+
   # split by ","
   splitted_string <- unlist(strsplit(x, split = ","))
-  
+
   # subsitute dummy
   splitted_string <- gsub(pattern = ";;;ABC;;;", replacement = ",",
                           splitted_string, fixed = TRUE)
-  
+
   # extract measurement name
   measurement_df <- data.frame(measurement = splitted_string[1])
-  
+
   # extract tags and tag values
   if (identical(splitted_string[-1], character(0))) {
     warning(paste("measurement does not have any attributes:", x))
     return(NULL)
   }
-  
+
   df <- strsplit(x = splitted_string[-1], split = "=")
   df <- do.call(cbind, df)
-  
+
   # create result df with tag names as colnames
   result <- data.frame(t(df[2, ]), stringsAsFactors = FALSE)
   colnames(result) <- df[1, ]
-  
+
   # combine measurement name and tagkeys and tagvalues
   result <- cbind(measurement_df, result)
-  
+
   return(result)
-  
+
 }
 
-
-# substitute special characters to comfort InfluxDB line protocol
-# function is not exported
-#' @keywords internal
-replace_spec_char <- function(x, chars) {
-  for (char in chars) {
-    x <- gsub(char, replacement = paste0("\\\\", char), x = x)
+replace_spec_char <- function(x, do_equal = TRUE) {
+  regexp <- if (do_equal) "([,= ])" else "([, ])"
+  if (is.factor(x)) {
+    # optimization for factors
+    levels(x) <- gsub(regexp, "\\\\\\1", levels(x))
+  } else if (is.character(x)) {
+    x <- gsub(regexp, "\\\\\\1", x)
   }
-  return(x)
+  x
 }
 
+double_quote <- function(x) {
+  if (is.factor(x)) {
+    levels(x) <- paste0("\"", levels(x), "\"")
+  } else if (is.character(x)) {
+    x <- paste0("\"", x, "\"")
+  }
+  x
+}
+
+validate_scalar_var <- function(x, name, must_contain = TRUE) {
+  var <- deparse(substitute(name))
+  if (length(name) > 1)
+    stop(sprintf("'%s' must be a scalar string.", var))
+  if (must_contain && is.null(x[[name]]))
+    stop(sprintf("'%s' is not in the data.frame (%s)", name, var))
+}
+
+format_time <- function(time, precision) {
+  time <- as.numeric(time) * get_precision_divisor(precision)
+  format(time, trim = TRUE, scientific = FALSE)
+}

--- a/R/influxdb_write.R
+++ b/R/influxdb_write.R
@@ -1,25 +1,65 @@
+split_ixes <- function(nrows, max_points) {
+  # split xts object into a list of xts objects to reduce batch size
+  split(1:nrows, rep(1:ceiling((nrows / max_points)), each = max_points)[1:nrows])
+}
+
+write_batched <- function(x, con, query, measurement = NULL, measurement_col = NULL,
+                          time_col = NULL, tag_cols = NULL, use_integers = FALSE,
+                          max_points = 5000, progress_bar = TRUE, batch_processor = identity) {
+  # split xts object into a list of xts objects to reduce batch size
+  ixes <- split_ixes(nrow(x), max_points)
+
+  response <- list()
+
+  do_pb <- progress_bar && length(ixes) > 1
+
+  if (do_pb) {
+    pb <- progress::progress_bar$new(format = " Writing [:bar] :percent :elapsed eta: :eta",
+      total = length(ixes), width = 100, clear = FALSE)
+
+    pb$tick(0)
+  }
+
+  for (i in seq_along(ixes)) {
+    resp <-
+      x[ixes[[i]], ] %>%
+      batch_processor() %>%
+      convert_to_line_protocol(measurement = measurement,
+        measurement_col = measurement_col,
+        time_col = time_col,
+        tag_cols = tag_cols,
+        precision = query$precision,
+        use_integers = use_integers) %>%
+      httr_POST(con = con, query = query, body = ., endpoint = "write") %>%
+      check_srv_comm(.)
+
+    response[[length(response) + 1]] <- resp
+
+    if (do_pb)
+      pb$tick()
+  }
+
+  invisible(response)
+}
+
 #' @title Write an xts or data.frame object to an InfluxDB server
-#' 
+#'
 #' @description This function writes either an `xts` object or a `data.frame` to an InfluxDB server.
 #' In case of an xts object, columnnames of the `xts` object are used as InfluxDB's field keys,
 #' `xts`'s coredata represent field values. Attributes are preserved and written
 #' as tag keys and values, respectively.
-#' 
+#'
 #' In case of a `data.frame`, columns may represent times and both tag and field values.
 #' Columnnames of the `data.frame` object are used as InfluxDB's tag and field keys.
-#' Times and tags are optional. Use parameter `time_col` and `tag_col` to define 
-#' the interpretation. By specifiying one of the arguments `measurement` or `measurement_col`, 
+#' Times and tags are optional. Use parameter `time_col` and `tag_col` to define
+#' the interpretation. By specifiying one of the arguments `measurement` or `measurement_col`,
 #' a data.frame may contain data from one measurement or multiple measurements, respectively.
-#' 
+#'
 #' @inheritParams influx_query
 #' @param x The object to write to an InfluxDB server (either of class `xts` or `data.frame`).
 #' @param measurement Sets the name of the measurement (data.frame has data to write
-#' to one measurement only). If both arguments `measurement` and `measurement_col` 
+#' to one measurement only). If both arguments `measurement` and `measurement_col`
 #' are given, `measurement` gets overridden.
-#' @param time_col A character scalar naming the time index column.
-#' @param tag_cols A character vector naming tag columns.
-#' @param measurement_col A character scalar naming the measurement column (data.frame 
-#' has data to write to multiple measurements). Overrides `measurement` argument.
 #' @param rp Sets the target retention policy for the write. If not present the
 #' default retention policy is used.
 #' @param precision Sets the precision of the supplied Unix time values
@@ -31,141 +71,101 @@
 #' fail.
 #' @param max_points Defines the maximum points per batch (defaults to 5000).
 #' @param use_integers Should integers (instead of doubles) be written if present?
+#' @param progress_bar \code{TRUE} if progress bar should be shown.
 #' @param ... Arguments to be passed to methods.
+#' @param time_col A character scalar naming the time index column.
+#' @param tag_cols A character vector naming tag columns.
+#' @param measurement_col A character scalar naming the measurement column (data.frame
+#' has data to write to multiple measurements). Overrides `measurement` argument.
 #' @return A list of server responses.
 #' @name influx_write
 #' @export
 #' @seealso \code{\link[xts]{xts}}, \code{\link[influxdbr]{influx_connection}}
 #' @references \url{https://docs.influxdata.com/influxdb/}
-influx_write <- function(x, 
-                         con, 
-                         db, 
+influx_write <- function(x,
+                         con,
+                         db,
                          measurement,
-                         rp = NULL, 
-                         precision = c("s", "ns", "u", "ms", "m", "h"), 
-                         consistency = c(NULL, "one", "quroum", "all", "any"), 
-                         max_points = 5000, 
-                         use_integers = FALSE, 
+                         rp = NULL,
+                         precision = c("s", "ns", "u", "ms", "m", "h"),
+                         consistency = c(NULL, "one", "quroum", "all", "any"),
+                         max_points = 5000,
+                         use_integers = FALSE,
+                         progress_bar = TRUE,
                          ...) {
-  
+
   UseMethod("influx_write", x)
-  
 }
 
 #' @export
 #' @rdname influx_write
-influx_write.xts <- function(x, 
-                             con, 
-                             db, 
-                             measurement, 
-                             rp = NULL, 
-                             precision = c("s", "ns", "u", "ms", "m", "h"), 
-                             consistency = c(NULL, "one", "quroum", "all", "any"), 
-                             max_points = 5000, 
+influx_write.xts <- function(x,
+                             con,
+                             db,
+                             measurement,
+                             rp = NULL,
+                             precision = c("s", "ns", "u", "ms", "m", "h"),
+                             consistency = c(NULL, "one", "quroum", "all", "any"),
+                             max_points = 5000,
                              use_integers = FALSE,
+                             progress_bar = TRUE,
                              ...) {
-  
+
   # create query based on function parameters
   q <- list(db = db,
             u = con$user,
-            p = con$pass)
-  
-  # add precision parameter
-  precision <- match.arg(precision)
-  q <- c(q, precision = precision)
-  
-  # add retention policy
-  if (!is.null(rp))
-    q <- c(q, rp = rp)
-  
-  # add consistency parameter
-  if (!is.null(consistency)) {
-    q <- c(q, consistency = match.arg(consistency))
-  }
-  
-  # split xts object into a list of xts objects to reduce batch size
-  list_of_xts <- suppressWarnings(split(x,
-                                        rep(1:ceiling((nrow(x) / max_points)
-                                        ),
-                                        each = max_points)))
-  
-  # reclass xts objects (became "zoo" in previous split command)
-  list_of_xts <- lapply(list_of_xts, xts::as.xts)
-  
-  # reassign attributes to elements of list_of_xts
-  # (got lost in previous split command)
-  for (i in seq_len(length(list_of_xts))) {
-    xts::xtsAttributes(list_of_xts[[i]]) <- xts::xtsAttributes(x)
-  }
-  
-  
-  # conversion to influxdb line protocol and submit post
-  response <- list_of_xts %>% 
-    purrr::map( ~ convert_to_line_protocol(x, 
-                                           use_integers = use_integers,
-                                           measurement = measurement,
-                                           precision = precision) %>% 
-                  httr_POST(con = con, query = q, body = ., endpoint = "write") %>% 
-                  check_srv_comm(.)
-    )
-  
-  invisible(response)
-  
+            p = con$pass,
+            rp = rp,
+            precision = match.arg(precision),
+            consistency = match.arg(consistency))
+
+  write_batched(x,
+    con = con,
+    query = q,
+    measurement = measurement,
+    progress_bar = progress_bar,
+    max_points = max_points,
+    batch_processor = function(xi) {
+      xts::xtsAttributes(xi) <- xts::xtsAttributes(x)
+      xi
+    }
+  )
 }
-  
+
 #' @export
 #' @rdname influx_write
-influx_write.data.frame <- function(x, 
-                                    con, 
-                                    db, 
+influx_write.data.frame <- function(x,
+                                    con,
+                                    db,
                                     measurement = NULL,
-                                    rp = NULL, 
-                                    precision = c("s", "ns", "u", "ms", "m", "h"), 
-                                    consistency = c(NULL, "one", "quroum", "all", "any"), 
-                                    max_points = 5000, 
+                                    rp = NULL,
+                                    precision = c("s", "ns", "u", "ms", "m", "h"),
+                                    consistency = c(NULL, "one", "quroum", "all", "any"),
+                                    max_points = 5000,
                                     use_integers = FALSE,
-                                    time_col = NULL, 
+                                    time_col = NULL,
                                     tag_cols = NULL,
                                     measurement_col = NULL,
+                                    progress_bar = TRUE,
                                     ...) {
-  
+
   # create query based on function parameters
   q <- list(db = db,
             u = con$user,
-            p = con$pass)
-  
-  # add precision parameter
-  precision <- match.arg(precision)
-  q <- c(q, precision = precision)
-  
-  # add retention policy
-  if (!is.null(rp))
-    q <- c(q, rp = rp)
-  
-  # add consistency parameter
-  if (!is.null(consistency)) {
-    q <- c(q, consistency = match.arg(consistency))
-  }
-  
-  # split xts object into a list of xts objects to reduce batch size
-  list_of_df <- suppressWarnings(split(x,
-                                       rep(1:ceiling((nrow(x) / max_points)),
-                                           each = max_points))
-  )
-  
-  # conversion to influxdb line protocol and submit post
-  response <- list_of_df %>% 
-    purrr::map( ~ convert_to_line_protocol(x,
-                                           measurement = measurement,
-                                           measurement_col = measurement_col,
-                                           time_col = time_col,
-                                           tag_cols = tag_cols,
-                                           precision = precision,
-                                           use_integers = use_integers) %>% 
-                  httr_POST(con = con, query = q, body = ., endpoint = "write") %>% 
-                  check_srv_comm(.)
-    )
-  
-  invisible(response)
-  
+            p = con$pass,
+            precision = match.arg(precision),
+            rp = rp,
+            consistency = match.arg(consistency))
+
+  write_batched(x,
+    con = con,
+    query = q,
+    measurement = measurement,
+    measurement_col = measurement_col,
+    time_col = time_col,
+    tag_cols = tag_cols,
+    use_integers = use_integers,
+    progress_bar = progress_bar,
+    max_points = max_points)
+
 }

--- a/R/influxdb_write.R
+++ b/R/influxdb_write.R
@@ -5,7 +5,8 @@ split_ixes <- function(nrows, max_points) {
 
 write_batched <- function(x, con, query, measurement = NULL, measurement_col = NULL,
                           time_col = NULL, tag_cols = NULL, use_integers = FALSE,
-                          max_points = 5000, progress_bar = TRUE, batch_processor = identity) {
+                          max_points = 5000, progress_bar = getOption("influxdbr.progress_bar", TRUE),
+                          batch_processor = identity) {
   # split xts object into a list of xts objects to reduce batch size
   ixes <- split_ixes(nrow(x), max_points)
 
@@ -56,27 +57,30 @@ write_batched <- function(x, con, query, measurement = NULL, measurement_col = N
 #' a data.frame may contain data from one measurement or multiple measurements, respectively.
 #'
 #' @inheritParams influx_query
-#' @param x The object to write to an InfluxDB server (either of class `xts` or `data.frame`).
-#' @param measurement Sets the name of the measurement (data.frame has data to write
-#' to one measurement only). If both arguments `measurement` and `measurement_col`
-#' are given, `measurement` gets overridden.
+#' @param x The object to write to an InfluxDB server (either of class `xts` or
+#'   `data.frame`).
+#' @param measurement Sets the name of the measurement (data.frame has data to
+#'   write to one measurement only). If both arguments `measurement` and
+#'   `measurement_col` are given, `measurement` gets overridden.
 #' @param rp Sets the target retention policy for the write. If not present the
-#' default retention policy is used.
-#' @param precision Sets the precision of the supplied Unix time values
-#' ("s", "ns", "u", "ms", "m", "h"). If not present timestamps are assumed to be
-#' in seconds.
-#' @param consistency Set the number of nodes that must confirm the write.
-#' If the requirement is not met the return value will be partial write
-#' if some points in the batch fail, or write failure if all points in the batch
-#' fail.
+#'   default retention policy is used.
+#' @param precision Sets the precision of the supplied Unix time values ("s",
+#'   "ns", "u", "ms", "m", "h"). If not present timestamps are assumed to be in
+#'   seconds.
+#' @param consistency Set the number of nodes that must confirm the write. If
+#'   the requirement is not met the return value will be partial write if some
+#'   points in the batch fail, or write failure if all points in the batch fail.
 #' @param max_points Defines the maximum points per batch (defaults to 5000).
-#' @param use_integers Should integers (instead of doubles) be written if present?
-#' @param progress_bar \code{TRUE} if progress bar should be shown.
+#' @param use_integers Should integers (instead of doubles) be written if
+#'   present?
+#' @param progress_bar \code{TRUE} if progress bar should be shown. Honor the
+#'   "influxdbr.progress_bar" option and defaults to TRUE.
 #' @param ... Arguments to be passed to methods.
 #' @param time_col A character scalar naming the time index column.
 #' @param tag_cols A character vector naming tag columns.
-#' @param measurement_col A character scalar naming the measurement column (data.frame
-#' has data to write to multiple measurements). Overrides `measurement` argument.
+#' @param measurement_col A character scalar naming the measurement column
+#'   (data.frame has data to write to multiple measurements). Overrides
+#'   `measurement` argument.
 #' @return A list of server responses.
 #' @name influx_write
 #' @export
@@ -91,7 +95,7 @@ influx_write <- function(x,
                          consistency = c(NULL, "one", "quroum", "all", "any"),
                          max_points = 5000,
                          use_integers = FALSE,
-                         progress_bar = TRUE,
+                         progress_bar = getOption("influxdbr.progress_bar", TRUE),
                          ...) {
 
   UseMethod("influx_write", x)
@@ -107,8 +111,8 @@ influx_write.xts <- function(x,
                              precision = c("s", "ns", "u", "ms", "m", "h"),
                              consistency = c(NULL, "one", "quroum", "all", "any"),
                              max_points = 5000,
-                             use_integers = FALSE,
-                             progress_bar = TRUE,
+                             use_integers = FALSE,                             
+                             progress_bar = getOption("influxdbr.progress_bar", TRUE),
                              ...) {
 
   # create query based on function parameters
@@ -143,7 +147,7 @@ influx_write.data.frame <- function(x,
                                     consistency = c(NULL, "one", "quroum", "all", "any"),
                                     max_points = 5000,
                                     use_integers = FALSE,
-                                    progress_bar = TRUE,
+                                    progress_bar = getOption("influxdbr.progress_bar", TRUE),
                                     time_col = NULL,
                                     tag_cols = NULL,
                                     measurement_col = NULL,

--- a/R/influxdb_write.R
+++ b/R/influxdb_write.R
@@ -143,10 +143,10 @@ influx_write.data.frame <- function(x,
                                     consistency = c(NULL, "one", "quroum", "all", "any"),
                                     max_points = 5000,
                                     use_integers = FALSE,
+                                    progress_bar = TRUE,
                                     time_col = NULL,
                                     tag_cols = NULL,
                                     measurement_col = NULL,
-                                    progress_bar = TRUE,
                                     ...) {
 
   # create query based on function parameters

--- a/man/influx_write.Rd
+++ b/man/influx_write.Rd
@@ -8,18 +8,19 @@
 \usage{
 influx_write(x, con, db, measurement, rp = NULL, precision = c("s",
   "ns", "u", "ms", "m", "h"), consistency = c(NULL, "one", "quroum",
-  "all", "any"), max_points = 5000, use_integers = FALSE, ...)
+  "all", "any"), max_points = 5000, use_integers = FALSE,
+  progress_bar = TRUE, ...)
 
 \method{influx_write}{xts}(x, con, db, measurement, rp = NULL,
   precision = c("s", "ns", "u", "ms", "m", "h"), consistency = c(NULL,
   "one", "quroum", "all", "any"), max_points = 5000,
-  use_integers = FALSE, ...)
+  use_integers = FALSE, progress_bar = TRUE, ...)
 
 \method{influx_write}{data.frame}(x, con, db, measurement = NULL,
   rp = NULL, precision = c("s", "ns", "u", "ms", "m", "h"),
   consistency = c(NULL, "one", "quroum", "all", "any"),
-  max_points = 5000, use_integers = FALSE, time_col = NULL,
-  tag_cols = NULL, measurement_col = NULL, ...)
+  max_points = 5000, use_integers = FALSE, progress_bar = TRUE,
+  time_col = NULL, tag_cols = NULL, measurement_col = NULL, ...)
 }
 \arguments{
 \item{x}{The object to write to an InfluxDB server (either of class \code{xts} or \code{data.frame}).}
@@ -47,6 +48,8 @@ fail.}
 \item{max_points}{Defines the maximum points per batch (defaults to 5000).}
 
 \item{use_integers}{Should integers (instead of doubles) be written if present?}
+
+\item{progress_bar}{\code{TRUE} if progress bar should be shown.}
 
 \item{...}{Arguments to be passed to methods.}
 

--- a/man/influx_write.Rd
+++ b/man/influx_write.Rd
@@ -9,47 +9,51 @@
 influx_write(x, con, db, measurement, rp = NULL, precision = c("s",
   "ns", "u", "ms", "m", "h"), consistency = c(NULL, "one", "quroum",
   "all", "any"), max_points = 5000, use_integers = FALSE,
-  progress_bar = TRUE, ...)
+  progress_bar = getOption("influxdbr.progress_bar", TRUE), ...)
 
 \method{influx_write}{xts}(x, con, db, measurement, rp = NULL,
   precision = c("s", "ns", "u", "ms", "m", "h"), consistency = c(NULL,
   "one", "quroum", "all", "any"), max_points = 5000,
-  use_integers = FALSE, progress_bar = TRUE, ...)
+  use_integers = FALSE,
+  progress_bar = getOption("influxdbr.progress_bar", TRUE), ...)
 
 \method{influx_write}{data.frame}(x, con, db, measurement = NULL,
   rp = NULL, precision = c("s", "ns", "u", "ms", "m", "h"),
   consistency = c(NULL, "one", "quroum", "all", "any"),
-  max_points = 5000, use_integers = FALSE, progress_bar = TRUE,
+  max_points = 5000, use_integers = FALSE,
+  progress_bar = getOption("influxdbr.progress_bar", TRUE),
   time_col = NULL, tag_cols = NULL, measurement_col = NULL, ...)
 }
 \arguments{
-\item{x}{The object to write to an InfluxDB server (either of class \code{xts} or \code{data.frame}).}
+\item{x}{The object to write to an InfluxDB server (either of class \code{xts} or
+\code{data.frame}).}
 
 \item{con}{An \code{influx_connection} object (s. \code{\link{influx_connection}}).}
 
 \item{db}{Sets the target database for the query.}
 
-\item{measurement}{Sets the name of the measurement (data.frame has data to write
-to one measurement only). If both arguments \code{measurement} and \code{measurement_col}
-are given, \code{measurement} gets overridden.}
+\item{measurement}{Sets the name of the measurement (data.frame has data to
+write to one measurement only). If both arguments \code{measurement} and
+\code{measurement_col} are given, \code{measurement} gets overridden.}
 
 \item{rp}{Sets the target retention policy for the write. If not present the
 default retention policy is used.}
 
-\item{precision}{Sets the precision of the supplied Unix time values
-("s", "ns", "u", "ms", "m", "h"). If not present timestamps are assumed to be
-in seconds.}
+\item{precision}{Sets the precision of the supplied Unix time values ("s",
+"ns", "u", "ms", "m", "h"). If not present timestamps are assumed to be in
+seconds.}
 
-\item{consistency}{Set the number of nodes that must confirm the write.
-If the requirement is not met the return value will be partial write
-if some points in the batch fail, or write failure if all points in the batch
-fail.}
+\item{consistency}{Set the number of nodes that must confirm the write. If
+the requirement is not met the return value will be partial write if some
+points in the batch fail, or write failure if all points in the batch fail.}
 
 \item{max_points}{Defines the maximum points per batch (defaults to 5000).}
 
-\item{use_integers}{Should integers (instead of doubles) be written if present?}
+\item{use_integers}{Should integers (instead of doubles) be written if
+present?}
 
-\item{progress_bar}{\code{TRUE} if progress bar should be shown.}
+\item{progress_bar}{\code{TRUE} if progress bar should be shown. Honor the
+"influxdbr.progress_bar" option and defaults to TRUE.}
 
 \item{...}{Arguments to be passed to methods.}
 
@@ -57,8 +61,9 @@ fail.}
 
 \item{tag_cols}{A character vector naming tag columns.}
 
-\item{measurement_col}{A character scalar naming the measurement column (data.frame
-has data to write to multiple measurements). Overrides \code{measurement} argument.}
+\item{measurement_col}{A character scalar naming the measurement column
+(data.frame has data to write to multiple measurements). Overrides
+\code{measurement} argument.}
 }
 \value{
 A list of server responses.

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,5 @@
 library(testthat)
+library(magrittr)
 library(influxdbr)
 
 test_check("influxdbr")

--- a/tests/testthat/test_write.R
+++ b/tests/testthat/test_write.R
@@ -1,306 +1,348 @@
-
 testthat::context("testing influx_write")
 
+## testthat currently fails badly on tibbles
+DF <- as.data.frame
+
+## setup df
+
+time0 <- .POSIXct(0, tz = "UTC")
+set.seed(100)
+df <- tibble::tibble(time = seq(from = time0, by = "-5 min", length.out = 10),
+                     `tag_one,` = sample(LETTERS[1:5], 10, replace = T),
+                     tag_two = sample(LETTERS[1:5], 10, replace = T),
+                     `tag three` = sample(paste(LETTERS[1:5], "tag"), 10, replace = T),
+                     field_chr = sample(paste(" ", LETTERS[1:5], "field"), 10, replace = T),
+                     field_float = stats::runif(10),
+                     field_int = sample(1:100000000,10),
+                     field_bool = stats::runif(10) > 0.5) %>% dplyr::arrange(time)
+df[1:3, "tag_two"] <- c("B,C", "B C", "B=C")
+df[1:3, "field_chr"] <- c(" B,C", " B C", " B=C")
+
+# NAs not supported!
+# df[c(3, 8), c(5)] <- NA
+# df[c(4), c(6)] <- NA
+# df[c(2), c(7)] <- NA
+# df[c(4,6), c(7)] <- NA
+
+
 # setup influx connection
-
 testthat::test_that("connection", {
-  
+
   # only local tests
   testthat::skip_on_cran()
   testthat::skip_on_travis()
-  
+
   con <<- influx_connection(group = "admin")
-  
+  drop_database(con, "test")
+  create_database(con, "test")
+
   testthat::expect_is(object = con, class = "list")
-  
-})
-
-testthat::test_that("write xts with NA", { 
-  
-  # only local tests
-  testthat::skip_on_cran()
-  testthat::skip_on_travis()
-  
-  # prepare tmp xts object
-  tmp <- xts::xts(x = runif(1e1),
-                  order.by = seq(as.POSIXct("1970-1-1"), by = "hours", length.out = 1e1))
-  colnames(tmp) <- "one"
-  # add second column
-  tmp <- cbind(tmp, tmp)
-  colnames(tmp) <- c("one", "two")
-  
-  # numeric matrix
-  tmp[8,1] <- NA
-  tmp[3,2] <- NA
-  influx_write(con = con, db = "test", x = tmp, measurement = "test_num")
-  influx_query(con = con, db = "test", query = "SELECT * from test_num")
-  
-  # integer matrix
-  tmp[,1] <- 1:10
-  tmp[,2] <- 20:21
-  tmp[8,1] <- NA
-  tmp[3,2] <- NA
-  influx_write(con = con, db = "test", x = tmp, measurement = "test_int", use_integers = T)
-  influx_query(con = con, db = "test", query = "SELECT * from test_int")
-  
-  # character matrix
-  tmp[,1] <- paste0("NAME", 1:10)
-  tmp[,2] <- paste0("NAME_TWO_", 1:10)
-  tmp[8,1] <- NA
-  tmp[3,2] <- NA
-  influx_write(con = con, db = "test", x = tmp, measurement = "test_str")
-  influx_query(con = con, db = "test", query = "SELECT * from test_str")
-  
-  # mixed data.frame
-  tmp_length <- 1e2
-  tmp1 <- xts::xts(x = 1:tmp_length, 
-                   order.by =  seq(as.POSIXct("1970-1-1"), by = "mins", length.out = tmp_length))
-  tmp2 <- xts::xts(x = paste0("NAME_TWO_", 1:tmp_length),
-                   order.by =  zoo::index(tmp1))
-  tmp1[8] <- NA
-  tmp2[3] <- NA
-  colnames(tmp1) <- c("one")
-  colnames(tmp2) <- c("two")
-  system.time(influx_write(con = con, db = "test", x = tmp1, measurement = "test_df"))
-  system.time(influx_write(con = con, db = "test", x = tmp2, measurement = "test_df"))
-  system.time(tmp <- influx_query(con = con, db = "test", query = "SELECT * from test_df limit 1000"))
-  
-  # delete measurements
-  purrr::walk(paste("test", c("num", "int", "str", "df"), sep = "_"), ~ drop_measurement(con, "test", .))
 
 })
 
-testthat::test_that("write xts with sub-second accuracy", { 
-  
-  # only local tests
-  testthat::skip_on_cran()
-  testthat::skip_on_travis()
-  
-  # how many digits to print?
-  options(digits.secs = 3)
-  
-  tmp <- xts::xts(runif(10), order.by = runif(10) + Sys.time())
-  colnames(tmp) <- c("accuracy")
-  influx_write(con = con, db = "test", x = tmp, measurement = "subsecond_acc", precision = "ms")
-  tmp_subsecond <- influx_query(con = con, db = "test", query = "SELECT * from subsecond_acc ORDER BY time DESC LIMIT 10")
+## testthat::test_that("write xts with NA", {
 
-  testthat::expect_is(object = tmp_subsecond, class = "list")
-  
-  # delete measurement
-  drop_measurement(con, "test", "subsecond_acc")
+##   # only local tests
+##   testthat::skip_on_cran()
+##   testthat::skip_on_travis()
 
-})
-  
+##   # prepare tmp xts object
+##   tmp <- xts::xts(x = runif(1e1),
+##                   order.by = seq(as.POSIXct("1970-1-1"), by = "hours", length.out = 1e1))
+##   colnames(tmp) <- "one"
+##   # add second column
+##   tmp <- cbind(tmp, tmp)
+##   colnames(tmp) <- c("one", "two")
+
+##   # numeric matrix
+##   tmp[8,1] <- NA
+##   tmp[3,2] <- NA
+##   influx_write(con = con, db = "test", x = tmp, measurement = "test_num")
+##   influx_query(con = con, db = "test", query = "SELECT * from test_num")
+
+##   # integer matrix
+##   tmp[,1] <- 1:10
+##   tmp[,2] <- 20:21
+##   tmp[8,1] <- NA
+##   tmp[3,2] <- NA
+##   influx_write(con = con, db = "test", x = tmp, measurement = "test_int", use_integers = T)
+##   influx_query(con = con, db = "test", query = "SELECT * from test_int")
+
+##   # character matrix
+##   tmp[,1] <- paste0("NAME", 1:10)
+##   tmp[,2] <- paste0("NAME_TWO_", 1:10)
+##   tmp[8,1] <- NA
+##   tmp[3,2] <- NA
+##   influx_write(con = con, db = "test", x = tmp, measurement = "test_str")
+##   influx_query(con = con, db = "test", query = "SELECT * from test_str")
+
+##   # mixed data.frame
+##   tmp_length <- 1e2
+##   tmp1 <- xts::xts(x = 1:tmp_length,
+##                    order.by =  seq(as.POSIXct("1970-1-1"), by = "mins", length.out = tmp_length))
+##   tmp2 <- xts::xts(x = paste0("NAME_TWO_", 1:tmp_length),
+##                    order.by =  zoo::index(tmp1))
+##   tmp1[8] <- NA
+##   tmp2[3] <- NA
+##   colnames(tmp1) <- c("one")
+##   colnames(tmp2) <- c("two")
+##   system.time(influx_write(con = con, db = "test", x = tmp1, measurement = "test_df"))
+##   system.time(influx_write(con = con, db = "test", x = tmp2, measurement = "test_df"))
+##   system.time(tmp <- influx_query(con = con, db = "test", query = "SELECT * from test_df limit 1000"))
+
+##   # delete measurements
+##   purrr::walk(paste("test", c("num", "int", "str", "df"), sep = "_"), ~ drop_measurement(con, "test", .))
+
+## })
+
+## testthat::test_that("write xts with sub-second accuracy", {
+
+##   # only local tests
+##   testthat::skip_on_cran()
+##   testthat::skip_on_travis()
+
+##   # how many digits to print?
+##   options(digits.secs = 3)
+
+##   tmp <- xts::xts(runif(10), order.by = runif(10) + Sys.time())
+##   colnames(tmp) <- c("accuracy")
+##   influx_write(con = con, db = "test", x = tmp, measurement = "subsecond_acc", precision = "ms")
+##   tmp_subsecond <- influx_query(con = con, db = "test", query = "SELECT * from subsecond_acc ORDER BY time DESC LIMIT 10")
+
+##   testthat::expect_is(object = tmp_subsecond, class = "list")
+
+##   # delete measurement
+##   drop_measurement(con, "test", "subsecond_acc")
+
+## })
+
 testthat::test_that("write data.frame with single measurement", {
-  
+
   # only local tests
   testthat::skip_on_cran()
   testthat::skip_on_travis()
-  
-  library(magrittr)
-  
-  df <- tibble::tibble(time = seq(from = Sys.time(), by = "-5 min", length.out = 10),
-                       `tag_one,` = sample(LETTERS[1:5], 10, replace = T),
-                       tag_two = sample(LETTERS[1:5], 10, replace = T),
-                       `tag three` = sample(paste(LETTERS[1:5], "tag"), 10, replace = T),
-                       field_chr = sample(paste(" ", LETTERS[1:5], "field"), 10, replace = T),
-                       field_float = stats::runif(10),
-                       field_int = sample(1:100000000,10),
-                       field_bool = stats::runif(10) > 0.5) %>%
-    dplyr::arrange(time)
-  
-  # NAs not supported!
-  # df[c(3, 8), c(5)] <- NA
-  # df[c(4), c(6)] <- NA
-  # df[c(2), c(7)] <- NA
-  # df[c(4,6), c(7)] <- NA
-  
-  influxdbr:::convert_to_line_protocol.data.frame(x = df,
-                                       measurement = "test",
-                                       #tag_cols = c("tag_one,", "tag_two", "tag three"),
-                                       time_col = "time",
-                                       precision = "s",
-                                       use_integers = FALSE)#%>% cat
-  
+
+  dfline <-
+    influxdbr:::convert_to_line_protocol.data.frame(
+      x = df %>% dplyr::mutate(tag_two = as.factor(tag_two)),
+      measurement = "test",
+      tag_cols = c("tag_one,", "tag_two", "tag three"),
+      time_col = "time",
+      precision = "s",
+      use_integers = FALSE) %>% strsplit("\n") %>% unlist()
+
+  testthat::expect_equal(
+    dfline,
+    c("test,tag_one\\,=A,tag_two=B\\,C,tag\\ three=B\\ tag field_chr=\" B,C\",field_float=0.307085896842182,field_int=21140856,field_bool=TRUE -2700",
+      "test,tag_one\\,=C,tag_two=B\\ C,tag\\ three=C\\ tag field_chr=\" B C\",field_float=0.207713897805661,field_int=59757530,field_bool=FALSE -2400",
+      "test,tag_one\\,=B,tag_two=B\\=C,tag\\ three=E\\ tag field_chr=\" B=C\",field_float=0.884227027418092,field_int=22990589,field_bool=FALSE -2100",
+      "test,tag_one\\,=E,tag_two=B,tag\\ three=D\\ tag field_chr=\"  A field\",field_float=0.780358511023223,field_int=12348724,field_bool=FALSE -1800",
+      "test,tag_one\\,=C,tag_two=D,tag\\ three=A\\ tag field_chr=\"  E field\",field_float=0.491231821943074,field_int=25339066,field_bool=FALSE -1500",
+      "test,tag_one\\,=C,tag_two=D,tag\\ three=C\\ tag field_chr=\"  D field\",field_float=0.603324356488883,field_int=59132106,field_bool=FALSE -1200",
+      "test,tag_one\\,=A,tag_two=B,tag\\ three=D\\ tag field_chr=\"  E field\",field_float=0.827303449623287,field_int=27488667,field_bool=TRUE  -900",
+      "test,tag_one\\,=C,tag_two=B,tag\\ three=C\\ tag field_chr=\"  B field\",field_float=0.777584439376369,field_int=23569431,field_bool=TRUE  -600",
+      "test,tag_one\\,=B,tag_two=E,tag\\ three=D\\ tag field_chr=\"  E field\",field_float=0.865120546659455,field_int=19867908,field_bool=TRUE  -300",
+      "test,tag_one\\,=B,tag_two=D,tag\\ three=C\\ tag field_chr=\"  C field\",field_float=0.330660525709391,field_int=33052985,field_bool=FALSE     0"
+    ))
+
+  influxdbr::drop_measurement(con, "test", "df2")
+
   # write full df
-  influxdbr::influx_write(x = df, 
+  influxdbr::influx_write(x = df,
                           con = con,
                           db = "test",
-                          measurement = "new_df2",
+                          measurement = "df2",
                           time_col = "time",
                           tag_cols = c("tag_one,", "tag_two", "tag three"),
                           max_points = 2,
                           use_integers = TRUE)
-  
-  # write df without tags
-  influxdbr::influx_write(x = df, 
-                          con = con,
-                          db = "test",
-                          measurement = "new_df3",
-                          time_col = "time",
-                          use_integers = TRUE)
-  
-  # write df without time
-  influxdbr::influx_write(x = df %>% 
-                            dplyr::mutate(time_chr = as.character(time)) %>% 
-                            dplyr::select(-time), 
-                          con = con,
-                          db = "test",
-                          measurement = "new_df4",
-                          tag_cols = c("tag_one,", "tag_two", "tag three"),
-                          use_integers = TRUE)
-  
-  # write only data
-  influxdbr::influx_write(x = df %>% 
-                            dplyr::mutate(time_chr = as.character(time)) %>% 
-                            dplyr::select(-time), 
-                          con = con,
-                          db = "test",
-                          # if no time and no tags are supplied, only one point is written
-                          # remember: points which don't have timestamps will get the same 
-                          # timestamp for the batch
-                          # therefore set at least a unique dummy tag:
-                          tag_cols = "time_chr", 
-                          measurement = "new_df5",
-                          precision = "ns",
-                          points = 1,
-                          use_integers = TRUE)
-  
+
   # query the data to check once again
-  tmp_df_full <-
-    influxdbr::influx_query(
+  df2 <-
+    influx_query(
       con = con,
       db = "test",
-      query = "select * from new_df2 group by *",
-      return_xts = FALSE
-    )
-  tmp_df_no_tags <-
-    influxdbr::influx_query(
+      query = "select * from df2",
+      return_xts = FALSE)[[1]][, names(df)] %>%
+    dplyr::mutate(field_int = as.integer(field_int))
+
+  # cannot use expect_equal due to a range of bugs in testthat
+  testthat::expect_equal(DF(df), DF(df2))
+
+  # write df without tags
+  influx_write(x = df,
+    con = con,
+    db = "test",
+    measurement = "df3",
+    time_col = "time",
+    use_integers = TRUE)
+
+  df3 <-
+    influx_query(
       con = con,
       db = "test",
-      query = "select * from new_df3 group by *",
-      return_xts = FALSE
-    )
-  tmp_df_no_time <-
-    influxdbr::influx_query(
+      query = "select * from df3",
+      return_xts = FALSE)[[1]][, names(df)]
+
+  testthat::expect_equal(DF(df), DF(df3))
+
+  # write df without time
+  dfa <- df %>%
+    dplyr::mutate(time_chr = as.character(time)) %>%
+    dplyr::select(-time)
+  influx_write(x = dfa,
+                 con = con,
+                 db = "test",
+                 measurement = "df4",
+                 tag_cols = c("tag_one,", "tag_two", "tag three"),
+                 use_integers = TRUE)
+
+  df4 <-
+    influx_query(
       con = con,
       db = "test",
-      query = "select * from new_df4 group by *",
+      query = "select * from df4",
       return_xts = FALSE,
-      timestamp_format = "ms"
-    )
-  tmp_df_data_only <-
-    influxdbr::influx_query(
+      timestamp_format = "ms")[[1]][, names(dfa)] %>% dplyr::arrange(time_chr)
+
+    testthat::expect_equal(DF(dfa), DF(df4))
+
+  # write only data
+  dfb <- df %>%
+    dplyr::mutate(time_chr = as.character(time)) %>%
+    dplyr::select(-time)
+  influx_write(x = dfb,
+    con = con,
+    db = "test",
+    # if no time and no tags are supplied, only one point is written
+    # remember: points which don't have timestamps will get the same
+    # timestamp for the batch
+    # therefore set at least a unique dummy tag:
+    tag_cols = "time_chr",
+    measurement = "df5",
+    precision = "ns",
+    points = 1,
+    use_integers = TRUE)
+
+  df5 <-
+    influx_query(
       con = con,
       db = "test",
-      query = "select * from new_df5 group by *",
+      query = "select * from df5",
       return_xts = FALSE,
-      timestamp_format = "ms"
-    )
-  tmp_xts <-
-    influxdbr::influx_query(
-      con = con,
-      db = "test",
-      query = "select * from new_df2 group by *",
-      return_xts = TRUE
-    )
-  
+      timestamp_format = "ms")[[1]][, names(dfb)] %>% dplyr::arrange(time_chr)
+
+  testthat::expect_equal(DF(dfb), DF(df5))
+
+
+  ## tmp_xts <-
+  ##   influxdbr::influx_query(
+  ##     con = con,
+  ##     db = "test",
+  ##     query = "select * from new_df2 group by *",
+  ##     return_xts = TRUE
+  ##   )
+
   # delete measurements
-  purrr::walk(paste0("new_df", 2:5), ~ drop_measurement(con, "test", .))
-  
+  purrr::walk(paste0("df", 2:5), ~ drop_measurement(con, "test", .))
 })
-  
+
 testthat::test_that("write data.frame with multiple measurements", {
-  
+
   # only local tests
   testthat::skip_on_cran()
   testthat::skip_on_travis()
-  
+
   library(magrittr)
-  
-  df <- tibble::tibble(time = seq(from = Sys.time(), by = "-5 min", length.out = 10),
-                       `tag_one,` = sample(LETTERS[1:5], 10, replace = T),
-                       tag_two = sample(LETTERS[1:5], 10, replace = T),
-                       `tag three` = sample(paste(LETTERS[1:5], "tag"), 10, replace = T),
-                       field_chr = sample(paste(" ", LETTERS[1:5], "field"), 10, replace = T),
-                       field_float = stats::runif(10),
-                       field_int = sample(1:100000000,10),
-                       field_bool = stats::runif(10) > 0.5, 
-                       measurement = rep(c("one", "two", "three", "four", "five"), 2)) %>%
-    dplyr::arrange(time)
-  
+
+  df1 <- dplyr::bind_cols(df, measurement = rep(c("one", "two", "three", "four", "five"), 2))
+
   # NAs not supported!
   # df[c(3, 8), c(5)] <- NA
   # df[c(4), c(6)] <- NA
   # df[c(2), c(7)] <- NA
   # df[c(4,6), c(7)] <- NA
-  
-  influxdbr:::convert_to_line_protocol.data.frame(x = df,
-                                                  measurement = "test",
-                                                  #tag_cols = c("tag_one,", "tag_two", "tag three"),
-                                                  time_col = "time",
-                                                  measurement_col = "measurement",
-                                                  precision = "s",
-                                                  use_integers = FALSE) #%>% cat
-  
+
+  dlines <- influxdbr:::convert_to_line_protocol.data.frame(x = df1 %>% dplyr::mutate(tag_two = as.factor(tag_two)),
+                                                            tag_cols = c("tag_one,", "tag_two", "tag three"),
+                                                            time_col = "time",
+                                                            measurement_col = "measurement",
+                                                            precision = "s",
+                                                            use_integers = FALSE)
+
+  expect_equal(dlines,
+               c("one,tag_one\\,=A,tag_two=B\\,C,tag\\ three=B\\ tag field_chr=\" B,C\",field_float=0.307085896842182,field_int=21140856,field_bool=TRUE,measurement=\"one\" -2700",
+                 "two,tag_one\\,=C,tag_two=B\\ C,tag\\ three=C\\ tag field_chr=\" B C\",field_float=0.207713897805661,field_int=59757530,field_bool=FALSE,measurement=\"two\" -2400",
+                 "three,tag_one\\,=B,tag_two=B\\=C,tag\\ three=E\\ tag field_chr=\" B=C\",field_float=0.884227027418092,field_int=22990589,field_bool=FALSE,measurement=\"three\" -2100",
+                 "four,tag_one\\,=E,tag_two=B,tag\\ three=D\\ tag field_chr=\"  A field\",field_float=0.780358511023223,field_int=12348724,field_bool=FALSE,measurement=\"four\" -1800",
+                 "five,tag_one\\,=C,tag_two=D,tag\\ three=A\\ tag field_chr=\"  E field\",field_float=0.491231821943074,field_int=25339066,field_bool=FALSE,measurement=\"five\" -1500",
+                 "one,tag_one\\,=C,tag_two=D,tag\\ three=C\\ tag field_chr=\"  D field\",field_float=0.603324356488883,field_int=59132106,field_bool=FALSE,measurement=\"one\" -1200",
+                 "two,tag_one\\,=A,tag_two=B,tag\\ three=D\\ tag field_chr=\"  E field\",field_float=0.827303449623287,field_int=27488667,field_bool=TRUE,measurement=\"two\"  -900",
+                 "three,tag_one\\,=C,tag_two=B,tag\\ three=C\\ tag field_chr=\"  B field\",field_float=0.777584439376369,field_int=23569431,field_bool=TRUE,measurement=\"three\"  -600",
+                 "four,tag_one\\,=B,tag_two=E,tag\\ three=D\\ tag field_chr=\"  E field\",field_float=0.865120546659455,field_int=19867908,field_bool=TRUE,measurement=\"four\"  -300",
+                 "five,tag_one\\,=B,tag_two=D,tag\\ three=C\\ tag field_chr=\"  C field\",field_float=0.330660525709391,field_int=33052985,field_bool=FALSE,measurement=\"five\"     0"))
+
   # write full df
-  influxdbr::influx_write(x = df, 
-                          con = con,
-                          db = "test",
-                          measurement_col = "measurement",
-                          time_col = "time",
-                          tag_cols = c("tag_one,", "tag_two", "tag three"),
-                          use_integers = TRUE)
-  
-  res <-
-    influxdbr::influx_query(
+  df1a <- df1 %>% dplyr::mutate(field_int = as.integer(field_int))
+
+  influx_write(x = df1a,
+               con = con,
+               db = "test",
+               measurement_col = "measurement",
+               time_col = "time",
+               tag_cols = c("tag_one,", "tag_two", "tag three"),
+               use_integers = TRUE)
+
+  df2 <-
+    influx_query(
       con = con,
       db = "test",
-      query = paste("select * from", 
-                    c("one", "two", "three", "four", "five"), 
+      query = paste("select * from",
+                    c("one", "two", "three", "four", "five"),
                     "group by *", collapse = ";"),
-      return_xts = FALSE
-    )
-  
+      return_xts = FALSE) %>% dplyr::bind_rows() %>% .[, names(df1a)] %>% dplyr::arrange(time)
+
+  expect_equal(DF(dplyr::arrange(df1a, time)), DF(df2))
+
   # delete measurements
   purrr::walk(c("one", "two", "three", "four", "five"), ~ drop_measurement(con, "test", .))
-  
+
 })
 
 testthat::test_that("UTF-8 encodings", {
-  
+
   # only local tests
   testthat::skip_on_cran()
   testthat::skip_on_travis()
-  
+
   library(magrittr)
-  
+
   df <- tibble::tibble(time = seq(from = Sys.time(), by = "-5 min", length.out = 2),
                        value = runif(2),
                        unit = c("µg", "m³")) %>%
     dplyr::arrange(time)
-  
+
   # write full df
-  influxdbr::influx_write(x = df, 
+  influxdbr::influx_write(x = df,
                           con = con,
                           measurement = "utf",
                           db = "test",
                           time_col = "time",
                           tag_cols = "unit")
-  
+
   res <-
     influxdbr::influx_select(
       con = con,
       db = "test",
       measurement = "utf",
       field_keys = "value",
-      group_by = "*", 
+      group_by = "*",
       return_xts = FALSE
     )
-  
+
   # delete measurements
   drop_measurement(con, "test", "utf")
-  
+
   testthat::expect_equal(res[[1]]$unit, df$unit)
-  
+
 })

--- a/tests/testthat/test_write.R
+++ b/tests/testthat/test_write.R
@@ -16,7 +16,7 @@ df <- tibble::tibble(time = seq(from = time0, by = "-5 min", length.out = 10),
                      field_int = sample(1:100000000,10),
                      field_bool = stats::runif(10) > 0.5) %>% dplyr::arrange(time)
 df[1:3, "tag_two"] <- c("B,C", "B C", "B=C")
-df[1:3, "field_chr"] <- c(" B,C", " B C", " B=C")
+df[1:4, "field_chr"] <- c(" B,C", " B C", " B=C", " \"D\" ")
 
 # NAs not supported!
 # df[c(3, 8), c(5)] <- NA
@@ -133,17 +133,16 @@ testthat::test_that("write data.frame with single measurement", {
 
   testthat::expect_equal(
     dfline,
-    c("test,tag_one\\,=A,tag_two=B\\,C,tag\\ three=B\\ tag field_chr=\" B,C\",field_float=0.307085896842182,field_int=21140856,field_bool=TRUE -2700",
-      "test,tag_one\\,=C,tag_two=B\\ C,tag\\ three=C\\ tag field_chr=\" B C\",field_float=0.207713897805661,field_int=59757530,field_bool=FALSE -2400",
-      "test,tag_one\\,=B,tag_two=B\\=C,tag\\ three=E\\ tag field_chr=\" B=C\",field_float=0.884227027418092,field_int=22990589,field_bool=FALSE -2100",
-      "test,tag_one\\,=E,tag_two=B,tag\\ three=D\\ tag field_chr=\"  A field\",field_float=0.780358511023223,field_int=12348724,field_bool=FALSE -1800",
-      "test,tag_one\\,=C,tag_two=D,tag\\ three=A\\ tag field_chr=\"  E field\",field_float=0.491231821943074,field_int=25339066,field_bool=FALSE -1500",
-      "test,tag_one\\,=C,tag_two=D,tag\\ three=C\\ tag field_chr=\"  D field\",field_float=0.603324356488883,field_int=59132106,field_bool=FALSE -1200",
-      "test,tag_one\\,=A,tag_two=B,tag\\ three=D\\ tag field_chr=\"  E field\",field_float=0.827303449623287,field_int=27488667,field_bool=TRUE  -900",
-      "test,tag_one\\,=C,tag_two=B,tag\\ three=C\\ tag field_chr=\"  B field\",field_float=0.777584439376369,field_int=23569431,field_bool=TRUE  -600",
-      "test,tag_one\\,=B,tag_two=E,tag\\ three=D\\ tag field_chr=\"  E field\",field_float=0.865120546659455,field_int=19867908,field_bool=TRUE  -300",
-      "test,tag_one\\,=B,tag_two=D,tag\\ three=C\\ tag field_chr=\"  C field\",field_float=0.330660525709391,field_int=33052985,field_bool=FALSE     0"
-    ))
+    c("test,tag_one\\,=A,tag_two=B\\,C,tag\\ three=B\\ tag field_chr=\" B,C\",field_float=0.307085896842182,field_int=21140856,field_bool=TRUE -2700", 
+      "test,tag_one\\,=C,tag_two=B\\ C,tag\\ three=C\\ tag field_chr=\" B C\",field_float=0.207713897805661,field_int=59757530,field_bool=FALSE -2400", 
+      "test,tag_one\\,=B,tag_two=B\\=C,tag\\ three=E\\ tag field_chr=\" B=C\",field_float=0.884227027418092,field_int=22990589,field_bool=FALSE -2100", 
+      "test,tag_one\\,=E,tag_two=B,tag\\ three=D\\ tag field_chr=\" \"D\" \",field_float=0.780358511023223,field_int=12348724,field_bool=FALSE -1800", 
+      "test,tag_one\\,=C,tag_two=D,tag\\ three=A\\ tag field_chr=\"  E field\",field_float=0.491231821943074,field_int=25339066,field_bool=FALSE -1500", 
+      "test,tag_one\\,=C,tag_two=D,tag\\ three=C\\ tag field_chr=\"  D field\",field_float=0.603324356488883,field_int=59132106,field_bool=FALSE -1200", 
+      "test,tag_one\\,=A,tag_two=B,tag\\ three=D\\ tag field_chr=\"  E field\",field_float=0.827303449623287,field_int=27488667,field_bool=TRUE -900", 
+      "test,tag_one\\,=C,tag_two=B,tag\\ three=C\\ tag field_chr=\"  B field\",field_float=0.777584439376369,field_int=23569431,field_bool=TRUE -600", 
+      "test,tag_one\\,=B,tag_two=E,tag\\ three=D\\ tag field_chr=\"  E field\",field_float=0.865120546659455,field_int=19867908,field_bool=TRUE -300", 
+      "test,tag_one\\,=B,tag_two=D,tag\\ three=C\\ tag field_chr=\"  C field\",field_float=0.330660525709391,field_int=33052985,field_bool=FALSE 0"))
 
   influxdbr::drop_measurement(con, "test", "df2")
 
@@ -263,24 +262,24 @@ testthat::test_that("write data.frame with multiple measurements", {
   # df[c(2), c(7)] <- NA
   # df[c(4,6), c(7)] <- NA
 
-  dlines <- influxdbr:::convert_to_line_protocol.data.frame(x = df1 %>% dplyr::mutate(tag_two = as.factor(tag_two)),
+  dfline <- influxdbr:::convert_to_line_protocol.data.frame(x = df1 %>% dplyr::mutate(tag_two = as.factor(tag_two)),
                                                             tag_cols = c("tag_one,", "tag_two", "tag three"),
                                                             time_col = "time",
                                                             measurement_col = "measurement",
                                                             precision = "s",
                                                             use_integers = FALSE)
 
-  expect_equal(dlines,
-               c("one,tag_one\\,=A,tag_two=B\\,C,tag\\ three=B\\ tag field_chr=\" B,C\",field_float=0.307085896842182,field_int=21140856,field_bool=TRUE,measurement=\"one\" -2700",
-                 "two,tag_one\\,=C,tag_two=B\\ C,tag\\ three=C\\ tag field_chr=\" B C\",field_float=0.207713897805661,field_int=59757530,field_bool=FALSE,measurement=\"two\" -2400",
-                 "three,tag_one\\,=B,tag_two=B\\=C,tag\\ three=E\\ tag field_chr=\" B=C\",field_float=0.884227027418092,field_int=22990589,field_bool=FALSE,measurement=\"three\" -2100",
-                 "four,tag_one\\,=E,tag_two=B,tag\\ three=D\\ tag field_chr=\"  A field\",field_float=0.780358511023223,field_int=12348724,field_bool=FALSE,measurement=\"four\" -1800",
-                 "five,tag_one\\,=C,tag_two=D,tag\\ three=A\\ tag field_chr=\"  E field\",field_float=0.491231821943074,field_int=25339066,field_bool=FALSE,measurement=\"five\" -1500",
-                 "one,tag_one\\,=C,tag_two=D,tag\\ three=C\\ tag field_chr=\"  D field\",field_float=0.603324356488883,field_int=59132106,field_bool=FALSE,measurement=\"one\" -1200",
-                 "two,tag_one\\,=A,tag_two=B,tag\\ three=D\\ tag field_chr=\"  E field\",field_float=0.827303449623287,field_int=27488667,field_bool=TRUE,measurement=\"two\"  -900",
-                 "three,tag_one\\,=C,tag_two=B,tag\\ three=C\\ tag field_chr=\"  B field\",field_float=0.777584439376369,field_int=23569431,field_bool=TRUE,measurement=\"three\"  -600",
-                 "four,tag_one\\,=B,tag_two=E,tag\\ three=D\\ tag field_chr=\"  E field\",field_float=0.865120546659455,field_int=19867908,field_bool=TRUE,measurement=\"four\"  -300",
-                 "five,tag_one\\,=B,tag_two=D,tag\\ three=C\\ tag field_chr=\"  C field\",field_float=0.330660525709391,field_int=33052985,field_bool=FALSE,measurement=\"five\"     0"))
+  expect_equal(dfline,
+               c("one,tag_one\\,=A,tag_two=B\\,C,tag\\ three=B\\ tag field_chr=\" B,C\",field_float=0.307085896842182,field_int=21140856,field_bool=TRUE,measurement=\"one\" -2700", 
+                 "two,tag_one\\,=C,tag_two=B\\ C,tag\\ three=C\\ tag field_chr=\" B C\",field_float=0.207713897805661,field_int=59757530,field_bool=FALSE,measurement=\"two\" -2400", 
+                 "three,tag_one\\,=B,tag_two=B\\=C,tag\\ three=E\\ tag field_chr=\" B=C\",field_float=0.884227027418092,field_int=22990589,field_bool=FALSE,measurement=\"three\" -2100", 
+                 "four,tag_one\\,=E,tag_two=B,tag\\ three=D\\ tag field_chr=\" \"D\" \",field_float=0.780358511023223,field_int=12348724,field_bool=FALSE,measurement=\"four\" -1800", 
+                 "five,tag_one\\,=C,tag_two=D,tag\\ three=A\\ tag field_chr=\"  E field\",field_float=0.491231821943074,field_int=25339066,field_bool=FALSE,measurement=\"five\" -1500", 
+                 "one,tag_one\\,=C,tag_two=D,tag\\ three=C\\ tag field_chr=\"  D field\",field_float=0.603324356488883,field_int=59132106,field_bool=FALSE,measurement=\"one\" -1200", 
+                 "two,tag_one\\,=A,tag_two=B,tag\\ three=D\\ tag field_chr=\"  E field\",field_float=0.827303449623287,field_int=27488667,field_bool=TRUE,measurement=\"two\" -900", 
+                 "three,tag_one\\,=C,tag_two=B,tag\\ three=C\\ tag field_chr=\"  B field\",field_float=0.777584439376369,field_int=23569431,field_bool=TRUE,measurement=\"three\" -600", 
+                 "four,tag_one\\,=B,tag_two=E,tag\\ three=D\\ tag field_chr=\"  E field\",field_float=0.865120546659455,field_int=19867908,field_bool=TRUE,measurement=\"four\" -300", 
+                 "five,tag_one\\,=B,tag_two=D,tag\\ three=C\\ tag field_chr=\"  C field\",field_float=0.330660525709391,field_int=33052985,field_bool=FALSE,measurement=\"five\" 0"))
 
   # write full df
   df1a <- df1 %>% dplyr::mutate(field_int = as.integer(field_int))


### PR DESCRIPTION
Multiple fixes. Please see individual commits for details.  

I looked into the performance and as already observed in #45 the writing loop seem to hang (or at least takes forever) on large datasets. After optimizing the loop as per #51 I was getting about 2minutes per 2mil rows in a 6 column db on an SSD. This time was almost entirely (95%) due to string manipulation (paste, sub etc) on R side. I was able to optimize it down to a single call to `paste` and streamlined the `gsub` usage. Altogether I got down to 24 sec per 2mil rows which I believe is pretty close to bottom line which could be achieved without parallezation or dropping to C for the actual paste. 

The single paste now takes about 60% of time, and the single call to `format` of the time component takes 18% with my data. The latter can be optimized out, but I haven't done that. 

The new implementation has no external dependencies, so it proves the point for #54. 

Close #45, close #51, close #52 , close #53, close #55