### PR TITLE
Consider spaces in MEASUREMENT names

### DIFF
--- a/R/influxdb_database_management.R
+++ b/R/influxdb_database_management.R
@@ -65,7 +65,7 @@ drop_series <- function(con,
   
   query <- ifelse(is.null(measurement),
                   query,
-                  paste(query, "FROM", measurement))
+                  paste(query, "FROM", shQuote(measurement)))
   
   query <- ifelse(is.null(where),
                   query,
@@ -96,7 +96,7 @@ delete <- function(con,
   
   query <- ifelse(is.null(measurement),
                   query,
-                  paste(query, "FROM", measurement))
+                  paste(query, "FROM", shQuote(measurement)))
   
   query <- ifelse(is.null(where),
                   query,
@@ -123,7 +123,7 @@ drop_measurement <- function(con, db, measurement) {
     con = con,
     db = db,
     query = paste("DROP MEASUREMENT",
-                  measurement)
+                  shQuote(measurement))
   )
   
   if (!is.null(result)) {

--- a/R/influxdb_line_protocol.R
+++ b/R/influxdb_line_protocol.R
@@ -112,13 +112,13 @@ convert_to_line_protocol.xts <- function(x,
 
   # no tags assigned
   if (is.null(tag_values) | identical(character(0), tag_values)) {
-    influxdb_line_protocol <- paste(measurement,
+    influxdb_line_protocol <- paste(shQuote(measurement),
                                     values,
                                     time,
                                     collapse = "\n")
   } else {
     influxdb_line_protocol <- paste(
-      measurement,
+      shQuote(measurement),
       paste(",", tag_key_value, sep = ""),
       " ",
       values,

--- a/R/influxdb_schema_exploration.R
+++ b/R/influxdb_schema_exploration.R
@@ -58,7 +58,7 @@ show_series <- function(con,
                         where = NULL) {
   query <- ifelse(is.null(measurement),
                   "SHOW SERIES",
-                  paste("SHOW SERIES FROM", measurement))
+                  paste("SHOW SERIES FROM", shQuote(measurement)))
   
   query <- ifelse(is.null(where),
                   query,
@@ -83,7 +83,7 @@ show_series <- function(con,
 show_tag_keys <- function(con, db, measurement = NULL) {
   query <- ifelse(is.null(measurement),
                   "SHOW TAG KEYS",
-                  paste("SHOW TAG KEYS FROM", measurement))
+                  paste("SHOW TAG KEYS FROM", shQuote(measurement)))
   
   result <- influx_query(
     con = con,
@@ -107,7 +107,7 @@ show_tag_values <- function(con, db, measurement = NULL, key) {
   
   query <- ifelse(is.null(measurement),
                   "SHOW TAG VALUES",
-                  paste("SHOW TAG VALUES FROM", measurement)) %>%
+                  paste("SHOW TAG VALUES FROM", shQuote(measurement))) %>%
     paste(., " WITH KEY=", base::dQuote(key), sep = "")
   
   result <- influx_query(
@@ -127,7 +127,7 @@ show_tag_values <- function(con, db, measurement = NULL, key) {
 show_field_keys <- function(con, db, measurement = NULL) {
   query <- ifelse(is.null(measurement),
                   "SHOW FIELD KEYS",
-                  paste("SHOW FIELD KEYS FROM", measurement))
+                  paste("SHOW FIELD KEYS FROM", shQuote(measurement)))
   
   result <- influx_query(
     con = con,

--- a/R/influxdb_select.R
+++ b/R/influxdb_select.R
@@ -44,7 +44,8 @@ influx_select <- function(con,
   ### Select all data from more than one measurement
   measurement <- paste(measurement, collapse = ", ")
   
-  query <- paste("SELECT", field_keys, "FROM", measurement)
+  query <- paste("SELECT", shQuote(field_keys), "FROM", 
+                 shQuote(measurement))
   
   query <- ifelse(is.null(where),
                   query,


### PR DESCRIPTION
We've had the issue with spaces in our sensornames and needed protect whitespaces with quotes around the sensornames, hope this is the right way how to do it